### PR TITLE
Review frontend for simple improvements

### DIFF
--- a/src/components/VivreFrance.jsx
+++ b/src/components/VivreFrance.jsx
@@ -659,19 +659,27 @@ function VivreFrance() {
                 <ul className="space-y-2">
                   <li className="flex items-center">
                     <ExternalLink className="h-4 w-4 mr-2 text-blue-600" />
-                    <a href="#" className="text-blue-600 hover:underline">CAF (aides logement)</a>
+                    <a href="https://www.caf.fr" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
+                      CAF (aides logement)
+                    </a>
                   </li>
                   <li className="flex items-center">
                     <ExternalLink className="h-4 w-4 mr-2 text-blue-600" />
-                    <a href="#" className="text-blue-600 hover:underline">Ameli.fr (sécurité sociale)</a>
+                    <a href="https://www.ameli.fr" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
+                      Ameli.fr (sécurité sociale)
+                    </a>
                   </li>
                   <li className="flex items-center">
                     <ExternalLink className="h-4 w-4 mr-2 text-blue-600" />
-                    <a href="#" className="text-blue-600 hover:underline">Service-public.fr</a>
+                    <a href="https://www.service-public.fr" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
+                      Service-public.fr
+                    </a>
                   </li>
                   <li className="flex items-center">
                     <ExternalLink className="h-4 w-4 mr-2 text-blue-600" />
-                    <a href="#" className="text-blue-600 hover:underline">Impots.gouv.fr</a>
+                    <a href="https://www.impots.gouv.fr" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
+                      Impots.gouv.fr
+                    </a>
                   </li>
                 </ul>
               </CardContent>
@@ -685,19 +693,27 @@ function VivreFrance() {
                 <ul className="space-y-2">
                   <li className="flex items-center">
                     <ExternalLink className="h-4 w-4 mr-2 text-blue-600" />
-                    <a href="#" className="text-blue-600 hover:underline">Leboncoin (petites annonces)</a>
+                    <a href="https://www.leboncoin.fr" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
+                      Leboncoin (petites annonces)
+                    </a>
                   </li>
                   <li className="flex items-center">
                     <ExternalLink className="h-4 w-4 mr-2 text-blue-600" />
-                    <a href="#" className="text-blue-600 hover:underline">Citymapper (transports)</a>
+                    <a href="https://citymapper.com/fr" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
+                      Citymapper (transports)
+                    </a>
                   </li>
                   <li className="flex items-center">
                     <ExternalLink className="h-4 w-4 mr-2 text-blue-600" />
-                    <a href="#" className="text-blue-600 hover:underline">Doctolib (rendez-vous médicaux)</a>
+                    <a href="https://www.doctolib.fr" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
+                      Doctolib (rendez-vous médicaux)
+                    </a>
                   </li>
                   <li className="flex items-center">
                     <ExternalLink className="h-4 w-4 mr-2 text-blue-600" />
-                    <a href="#" className="text-blue-600 hover:underline">Meetup (rencontres)</a>
+                    <a href="https://www.meetup.com/fr-FR" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
+                      Meetup (rencontres)
+                    </a>
                   </li>
                 </ul>
               </CardContent>


### PR DESCRIPTION
Fix broken links in the "Ressources utiles" section of the VivreFrance page.

This PR replaces placeholder links (`href="#"`) with actual URLs for public services and practical life resources, enhancing usability and providing correct external navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-87bd3bfd-0df8-459b-af40-d2b570bcaaf6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-87bd3bfd-0df8-459b-af40-d2b570bcaaf6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

